### PR TITLE
tag builds on main and gh-pages branch

### DIFF
--- a/.github/workflows/src-build.yml
+++ b/.github/workflows/src-build.yml
@@ -17,6 +17,13 @@ jobs:
       - name: Install firn
         run: chmod +x install-firn && sudo ./install-firn
       - run: firn build -d /home/runner/work/sunhypnotic.github.io/sunhypnotic.github.io/src
+      - name: Prepare tag
+        id: prepare_tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_NAME="${GITHUB_REF##refs/tags/}"
+          echo "::set-output name=tag_name::${TAG_NAME}"
+          echo "::set-output name=deploy_tag_name::deploy-${TAG_NAME}"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -37,3 +44,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
+          tag_message: 'Deployment ${{ steps.prepare_tag.outputs.tag_name }}'


### PR DESCRIPTION
This PR adds changes to src-build workflow to tag the src and the generated site deployed to gh-pages

fixes #7